### PR TITLE
Added helm repo documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # Directus Community Helm Charts
 
 This is the Community Helm Charts repository for [Directus](https://directus.io/), the open data platform for headless content management.
- 
+
+## Usage
+
+To install the Directus Helm charts, you need to add the following repository:
+
+```sh
+helm repo add directus https://github.com/directus-community/helm-chart
+```
+
 ## Documentation
 
-Chart documentation is found in [Directus directory](charts/directus/README.md)
+Chart documentation is found in [Directus directory](charts/directus/README.md).

--- a/charts/directus/README.md
+++ b/charts/directus/README.md
@@ -3,21 +3,25 @@
 Installs [Directus](https://directus.io/), the open data platform for headless content management via Helm Chart.
 
 ## Install
-To install Directus
+To install Directus, use the following commands.
 
-```
-$ git clone git@github.com:directus/directus.git
-$ cd charts/directus
+1. Add Directus Helm repository:
 
-$ helm dep up
-$ helm install directus .
-```
+    ```sh
+    helm repo add directus https://github.com/directus-community/helm-chart
+    helm repo update
+    ```
+
+2. Install Helm Chart with `directus-release` release name:
+    ```sh
+    helm install directus-release directus/directus
+    ```
 
 ## Uninstall
-To uninstall and delete Directus Helm release
+To uninstall and delete Directus Helm release:
 
-```
-$ helm delete directus 
+```sh
+helm delete directus-release 
 ```
 
 ## Configuration


### PR DESCRIPTION
* Updated documentation to use helm repo instead of git clone commands

NOTE: This requires an empty `gh-pages` branch before this PR is merged since it is being used as a helm registry.  The GitHub action is already in place to publish the Helm chart, but it is currently failing because of this missing branch.